### PR TITLE
feat: bootstrap extension with clock widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -18,5 +18,14 @@ The project embraces privacy and flexibility. All configuration is kept locally,
 ## Status
 This repository is the starting point. More documentation, code and widgets will follow as the project evolves.
 
+## Development
+
+The extension code lives in the `extension/` directory. To try it out:
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the `extension` folder.
+4. Open a new tab to see the clock widget.
+
 ---
 Bring unlimited power to your browser – *maximized pro-level ultra-ness* with zero subscriptions.

--- a/extension/clock.js
+++ b/extension/clock.js
@@ -1,0 +1,8 @@
+function updateClock() {
+  const now = new Date();
+  const clock = document.getElementById('clock');
+  clock.textContent = now.toLocaleTimeString();
+}
+
+setInterval(updateClock, 1000);
+updateClock();

--- a/extension/icons/icon.svg
+++ b/extension/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" fill="#1976d2"/>
+  <text x="64" y="72" font-size="64" text-anchor="middle" fill="white" font-family="Arial, sans-serif">N</text>
+</svg>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "newtab-pluspromaxultra",
+  "version": "0.1.0",
+  "description": "Experimental new tab page with a clock widget.",
+  "chrome_url_overrides": {
+    "newtab": "newtab.html"
+  },
+  "icons": {
+    "16": "icons/icon.svg",
+    "48": "icons/icon.svg",
+    "128": "icons/icon.svg"
+  }
+}

--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>newtab-pluspromaxultra</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="clock" class="widget clock-widget"></div>
+  <script src="clock.js"></script>
+</body>
+</html>

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -1,0 +1,14 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #222;
+  color: #eee;
+  font-family: sans-serif;
+}
+
+.clock-widget {
+  font-size: 4rem;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "newtab-pluspromaxultra",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "echo 'No tests yet'"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Chrome extension skeleton with new tab override
- show a simple clock widget on the new tab page
- document how to load the extension for development
- replace PNG icons with a single SVG icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f673014c833190c6462c20eeab69