### PR TITLE
Ensure settings panel hides correctly

### DIFF
--- a/extension/styles.css
+++ b/extension/styles.css
@@ -46,7 +46,7 @@ body {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .close-button {


### PR DESCRIPTION
## Summary
- Override ID styles by making `.hidden` class use `display: none !important` so the settings panel and button hide as expected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689612555b28833198dd2f6152791cfa