### PR TITLE
feat: add optional search widget autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An open-source, next-generation new tab page for Chrome that aims to rival leadi
 - **Custom backgrounds** – set a single image, cycle through images from albums or provide URLs for dynamic backgrounds.
 - **Purely local** – no subscriptions, no backend infrastructure. The extension reads and writes JSON configuration on the user's machine.
 - **Extensible defaults** – ships with a set of default widgets in JSON that can be tweaked or replaced entirely.
+- **Search widget autofocus** – optionally focus the search box as soon as a new tab opens so you can start typing right away.
 
 ## Philosophy
 The project embraces privacy and flexibility. All configuration is kept locally, and the widget system allows power users to exchange JSON configurations to extend or remix the default setup. If a widget needs external data (like weather or news), it fetches it directly from the web without passing through any server controlled by this project.

--- a/extension/widgets.js
+++ b/extension/widgets.js
@@ -408,7 +408,12 @@ function renderSearchWidget(widget, index) {
   }
 
   widgetGrid.appendChild(container);
-  
+
+  // Auto-focus the input if configured
+  if (widget.settings?.autoFocus) {
+    setTimeout(() => input.focus(), 0);
+  }
+
   // Return the input element for global keyboard handling
   return input;
 }
@@ -508,7 +513,8 @@ function addSearchWidget(options) {
       customUrl: options.customUrl,
       customImageUrl: options.customImageUrl,
       target: options.target,
-      clearAfterSearch: options.clearAfterSearch
+      clearAfterSearch: options.clearAfterSearch,
+      autoFocus: options.autoFocus
     }
   };
   settings.widgets.push(widget);
@@ -778,6 +784,9 @@ function openSearchConfig(existing, index) {
     <div class="input-group checkbox-group">
       <label><input type="checkbox" id="search-clear" ${existing && existing.settings.clearAfterSearch ? 'checked' : ''}> Clear input after search</label>
     </div>
+    <div class="input-group checkbox-group">
+      <label><input type="checkbox" id="search-autofocus" ${existing && existing.settings.autoFocus ? 'checked' : ''}> Auto-focus on new tab</label>
+    </div>
     <div class="widget-config-buttons">
       <button id="search-save">${isEdit ? 'Save' : 'Add'}</button>
       <button id="search-cancel">${isEdit ? 'Exit' : 'Cancel'}</button>
@@ -818,7 +827,8 @@ function openSearchConfig(existing, index) {
       customUrl: document.getElementById('search-custom-url').value.trim(),
       customImageUrl: document.getElementById('search-image-url').value.trim(),
       target: document.getElementById('search-target').value,
-      clearAfterSearch: document.getElementById('search-clear').checked
+      clearAfterSearch: document.getElementById('search-clear').checked,
+      autoFocus: document.getElementById('search-autofocus').checked
     };
     
     if (!options.customUrl) {


### PR DESCRIPTION
## Summary
- add "Auto-focus on new tab" option to search widget settings
- persist `autoFocus` flag and focus search input when enabled
- document optional search box auto-focus feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689693f71e6c8331a406e706ee101f43